### PR TITLE
Include Request Body & All Http Methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -1175,6 +1176,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2698,6 +2700,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom",
+ "rand",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Postie - a Postman alternative
+
+Postie is very much heavily in development but here are some it's early goals:
+- Be a free, feature parity (to a basic extent) alternative to Postman.
+Mainly started due to a need at work, where Postman cloud accounts are not allowed.
+- A basic extent means: making requests, saving request history, and being able to 
+save collections and environments.
+- Have full interoperability with existing Postman file formats.

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.22", features = ["blocking"] }
+reqwest = { version = "0.11.22", features = ["blocking", "json"] }
 serde = "1.0.188"
 serde_json = "1.0.107"
+uuid = { version = "1.4.1", features = ["v4", "fast-rng"] }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,14 +1,9 @@
 use std::error::Error;
 
-use reqwest::{Client, IntoUrl};
+use reqwest::{Client, Method};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
-
-enum InputAction {
-    SAVE_COLLECTION,
-    SAVE_ENVIRONMENT,
-    MAKE_REQUEST,
-}
+use serde_json::{json, Value};
+use uuid::Uuid;
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]
 pub enum HttpMethod {
@@ -23,11 +18,12 @@ pub enum HttpMethod {
 
 #[derive(Debug)]
 pub struct HttpRequest {
+    pub id: Uuid,
     pub name: Option<String>,
     pub method: HttpMethod,
     pub url: String,
     pub headers: Option<Vec<(String, String)>>,
-    pub body: Option<String>,
+    pub body: Option<Value>,
 }
 
 pub struct RequestCollection {
@@ -59,40 +55,35 @@ impl PostieApi {
         Ok(())
     }
     pub async fn make_request(input: HttpRequest) -> Result<Value, Box<dyn Error>> {
-        Ok(serde_json::json!({
-            "foo": "bar"
-        }))
+        let client = Client::new();
+        println!("Submitting request: {:?}", input);
+        let method = match input.method {
+            HttpMethod::GET => Method::GET,
+            HttpMethod::POST => Method::POST,
+            HttpMethod::PUT => Method::PUT,
+            HttpMethod::PATCH => Method::PATCH,
+            HttpMethod::DELETE => Method::DELETE,
+            HttpMethod::HEAD => Method::HEAD,
+            HttpMethod::OPTIONS => Method::OPTIONS,
+        };
+
+        let mut req = client
+            .request(method, input.url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
+        if input.body.is_some() {
+            req = req.json(&input.body.unwrap_or_default());
+        }
+
+        let res = req.send().await?;
+        let res_type = res.headers().get("content-type").unwrap().to_str().unwrap();
+        if !res_type.starts_with("application/json") {
+            // I couldn't figure out how to safely throw an error so I'm just returning this for now
+            println!("expected application/json, got {}", res_type);
+            return Ok(json!({"msg": "not JSON!"}));
+        }
+
+        let res_str = res.text().await?;
+        let res_json = serde_json::from_str(&res_str).unwrap_or_default();
+        Ok(res_json)
     }
-}
-pub fn save_environment(input: Environment) -> Result<(), Box<dyn Error>> {
-    Ok(())
-}
-pub fn save_collection(input: RequestCollection) -> Result<(), Box<dyn Error>> {
-    Ok(())
-}
-pub async fn submit_request(input: HttpRequest) -> Result<Value, Box<dyn Error>> {
-    println!("making client");
-    let client = Client::new();
-    println!("Submitting request: {:?}", input);
-    let res = match input.method {
-        HttpMethod::GET => client.get(input.url).send().await?,
-        HttpMethod::POST => todo!(),
-        HttpMethod::PUT => todo!(),
-        HttpMethod::PATCH => todo!(),
-        HttpMethod::DELETE => todo!(),
-        HttpMethod::OPTIONS => todo!(),
-        HttpMethod::HEAD => todo!(),
-    };
-
-    let res_type = res.headers().get("content-type").unwrap().to_str().unwrap();
-
-    if !res_type.starts_with("application/json") {
-        // I couldn't figure out how to safely throw an error so I'm just returning this for now
-        println!("expected application/json, got {}", res_type);
-        return Ok(json!({"msg": "not JSON!"}));
-    }
-
-    let res_str = res.text().await?;
-    let res_json = serde_json::from_str(&res_str).unwrap_or_default();
-    Ok(res_json)
 }

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -13,3 +13,4 @@ log = "0.4"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 tokio = { version = "1", features = ["full"] }
+uuid = { version = "1.4.1", features = ["v4", "fast-rng"] }


### PR DESCRIPTION
- update gui to have a text window for inserting request body.
- add deafult content-type header.
- bring in api changes from tqhoughton branch for suppporting other methods.
- start generating request ids on submission for use in db.