### PR TITLE
Add Headers Page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,10 @@ name = "accesskit"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76eb1adf08c5bcaa8490b9851fd53cca27fa9880076f178ea9d29f05196728a8"
+dependencies = [
+ "enumn",
+ "serde",
+]
 
 [[package]]
 name = "accesskit_consumer"
@@ -110,6 +114,7 @@ checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "serde",
  "version_check",
 ]
 
@@ -727,6 +732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdf4e52dbbb615cfd30cf5a5265335c217b5fd8d669593cea74a517d9c605af"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -770,6 +776,7 @@ dependencies = [
  "epaint",
  "log",
  "nohash-hasher",
+ "serde",
 ]
 
 [[package]]
@@ -787,6 +794,19 @@ dependencies = [
  "web-time",
  "webbrowser",
  "winit",
+]
+
+[[package]]
+name = "egui_extras"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ffe3fe5c00295f91c2a61a74ee271c32f74049c94ba0b1cea8f26eb478bc07"
+dependencies = [
+ "egui",
+ "enum-map",
+ "log",
+ "mime_guess",
+ "serde",
 ]
 
 [[package]]
@@ -811,6 +831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ef2b29de53074e575c18b694167ccbe6e5191f7b25fe65175a0d905a32eeec0"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -820,6 +841,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c188012f8542dee7b3996e44dd89461d64aa471b0a7c71a1ae2f595d259e96e5"
+dependencies = [
+ "enum-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d0b288e3bb1d861c4403c1774a6f7a798781dfc519b3647df2a3dd4ae95f25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -844,6 +886,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumn"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "epaint"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +910,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
+ "serde",
 ]
 
 [[package]]
@@ -1172,6 +1226,7 @@ dependencies = [
  "api",
  "eframe",
  "egui",
+ "egui_extras",
  "log",
  "serde",
  "serde_json",
@@ -1543,6 +1598,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2668,6 +2733,15 @@ checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
 dependencies = [
  "tempfile",
  "winapi",
+]
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,6 +1,9 @@
-use std::{error::Error, borrow::BorrowMut};
+use std::{borrow::BorrowMut, error::Error};
 
-use reqwest::{Client, Method, header::{HeaderMap, HeaderValue, HeaderName}};
+use reqwest::{
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -73,11 +76,9 @@ impl PostieApi {
                 let header_name = HeaderName::from_bytes(&key.as_bytes()).unwrap();
                 let header_value = HeaderValue::from_str(&value).unwrap();
                 headers.insert(header_name, header_value);
-            };
+            }
         };
-        let mut req = client
-            .request(method, input.url)
-            .headers(headers);
+        let mut req = client.request(method, input.url).headers(headers);
         if input.body.is_some() {
             req = req.json(&input.body.unwrap_or_default());
         }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,6 +1,6 @@
-use std::error::Error;
+use std::{error::Error, borrow::BorrowMut};
 
-use reqwest::{Client, Method};
+use reqwest::{Client, Method, header::{HeaderMap, HeaderValue, HeaderName}};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -67,9 +67,17 @@ impl PostieApi {
             HttpMethod::OPTIONS => Method::OPTIONS,
         };
 
+        let mut headers = HeaderMap::new();
+        if let Some(h) = input.headers {
+            for (key, value) in h {
+                let header_name = HeaderName::from_bytes(&key.as_bytes()).unwrap();
+                let header_value = HeaderValue::from_str(&value).unwrap();
+                headers.insert(header_name, header_value);
+            };
+        };
         let mut req = client
             .request(method, input.url)
-            .header(reqwest::header::CONTENT_TYPE, "application/json");
+            .headers(headers);
         if input.body.is_some() {
             req = req.json(&input.body.unwrap_or_default());
         }

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 api= { path = "../api/" }
 egui = "0.23.0"
+egui_extras = "0.23.0"
 eframe = "0.23.0"
 log = "0.4"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -229,16 +229,17 @@ impl App for Gui {
                         });
                     })
                     .body(|mut body| {
-                        for header in self.config.headers.borrow_mut().clone().iter_mut() {
+                        for header in self.config.headers.borrow_mut().iter_mut() {
                             body.row(30.0, |mut row| {
+                                let (enabled, key, value) = header;
                                 row.col(|ui| {
-                                    ui.checkbox(&mut header.0, "");
+                                    ui.checkbox(enabled, "");
                                 });
                                 row.col(|ui| {
-                                    ui.text_edit_singleline(&mut header.1);
+                                    ui.text_edit_singleline(key);
                                 });
                                 row.col(|ui| {
-                                    ui.text_edit_singleline(&mut header.2);
+                                    ui.text_edit_singleline(value);
                                 });
                             });
                         }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -151,13 +151,16 @@ impl App for Gui {
                     } else {
                         None
                     };
+                    let submitted_headers = self.config.headers
+                        .borrow_mut()
+                        .iter()
+                        .filter(|h| h.0 == true)
+                        .map(|h| (h.1.to_owned(), h.2.to_owned()))
+                        .collect();
                     let request = HttpRequest {
                         id: Uuid::new_v4(),
                         name: None,
-                        headers: Some(vec![(
-                            String::from("Content-Type"),
-                            String::from("application/json"),
-                        )]),
+                        headers: Some(submitted_headers),
                         body,
                         method: self.config.selected_http_method.clone(),
                         url: self.config.url.clone(),
@@ -210,7 +213,7 @@ impl App for Gui {
             }
             RequestWindowMode::HEADERS => {
                 CentralPanel::default().show(ctx, |ui| {
-                   let mut table = TableBuilder::new(ui)
+                   let table = TableBuilder::new(ui)
                        .striped(true)
                        .resizable(true)
                        .cell_layout(egui::Layout::left_to_right(egui::Align::Center))


### PR DESCRIPTION
Adding a new headers page makes use of a fancy new table. Set some default headers, and added some logic to only include headers that have the enabled checkbox checked. Confirmed from the api log of the incoming HttpRequest struct that headers are now being passed back!