### PR TITLE
Substitute env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "serde",
  "version_check",
@@ -159,6 +159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "api"
 version = "0.1.0"
 dependencies = [
@@ -166,7 +172,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tokio",
+ "url",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -197,6 +206,16 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -399,6 +418,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -739,6 +764,25 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
 
 [[package]]
 name = "der"
@@ -1134,6 +1178,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1252,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,13 +1275,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1242,13 +1320,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1474,6 +1563,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "http",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1675,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
 ]
+
+[[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "instant"
@@ -1828,7 +1944,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -1944,7 +2060,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -2350,13 +2466,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2366,7 +2505,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -2375,7 +2523,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2428,7 +2585,7 @@ version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2461,6 +2618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
 name = "rsa"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,7 +2638,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2619,6 +2782,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,7 +2853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2895,7 +3069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864b869fdf56263f4c95c45483191ea0af340f9f3e3e7b4d57a61c7c87a970db"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.4",
  "bitflags 2.4.0",
  "byteorder",
  "bytes",
@@ -2917,7 +3091,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -2937,7 +3111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7ae0e6a97fb3ba33b23ac2671a5ce6e3cabe003f451abd5a56e7951d975624"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.4",
  "bitflags 2.4.0",
  "byteorder",
  "crc",
@@ -2956,7 +3130,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha1",
@@ -3341,6 +3515,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3349,8 +3524,8 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
- "getrandom",
- "rand",
+ "getrandom 0.2.10",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3395,6 +3570,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -3856,6 +4037,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiremock"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f71803d3a1c80377a06221e0530be02035d5b3e854af56c6ece7ac20ac441d"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.21.4",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3940,7 +4143,7 @@ dependencies = [
  "nix 0.26.4",
  "once_cell",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -11,3 +11,8 @@ serde = "1.0.188"
 serde_json = "1.0.107"
 uuid = { version = "1.4.1", features = ["v4", "fast-rng"] }
 sqlx = { version = "0.7", features = [ "runtime-tokio", "sqlite" ] }
+tokio = { version = "1", features = ["full"] }
+url = "2.2"
+
+[dev-dependencies]
+wiremock = "0.5"

--- a/api/src/domain/environment.rs
+++ b/api/src/domain/environment.rs
@@ -14,5 +14,3 @@ pub struct EnvironmentValue {
     pub r#type: String,
     pub enabled: bool,
 }
-
-unsafe impl Send for EnvironmentFile {}

--- a/api/src/domain/environment.rs
+++ b/api/src/domain/environment.rs
@@ -14,3 +14,5 @@ pub struct EnvironmentValue {
     pub r#type: String,
     pub enabled: bool,
 }
+
+unsafe impl Send for EnvironmentFile{}

--- a/api/src/domain/environment.rs
+++ b/api/src/domain/environment.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EnvironmentFile {
     pub id: String,
     pub name: String,
     pub values: Option<Vec<EnvironmentValue>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EnvironmentValue {
     pub key: String,
     pub value: String,

--- a/api/src/domain/environment.rs
+++ b/api/src/domain/environment.rs
@@ -15,4 +15,4 @@ pub struct EnvironmentValue {
     pub enabled: bool,
 }
 
-unsafe impl Send for EnvironmentFile{}
+unsafe impl Send for EnvironmentFile {}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -32,7 +32,7 @@ pub struct HttpRequest {
     pub url: String,
     pub headers: Option<Vec<(String, String)>>,
     pub body: Option<Value>,
-    pub environment: Option<EnvironmentFile>,
+    pub environment: EnvironmentFile,
 }
 
 pub struct RequestCollection {
@@ -124,10 +124,7 @@ impl PostieApi {
             }
         };
 
-        let url = match input.environment {
-            Some(env) => Self::substitute_variables_in_url(&env, input.url.clone()),
-            None => input.url,
-        };
+        let url = Self::substitute_variables_in_url(&input.environment, input.url.clone());
         let mut req = self.client.request(method, url).headers(headers);
         if input.body.is_some() {
             req = req.json(&input.body.unwrap_or_default());

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -96,7 +96,7 @@ impl PostieApi {
             let url = values.iter().fold(raw_url, |acc, env_value| {
                 acc.replace(&format!("{{{{{}}}}}", env_value.key), &env_value.value)
             });
-            println!("substituted url url: {}", url);
+            println!("final url: {}", url);
             url
         } else {
             println!("env doesnt have values, returning original");

--- a/api/tests/api/api.rs
+++ b/api/tests/api/api.rs
@@ -1,0 +1,83 @@
+use api::{domain::environment::{EnvironmentFile, EnvironmentValue}, PostieApi};
+use reqwest::Url;
+use wiremock::Match;
+
+// wiremock matches dont include a raw url match? i think
+// i only saw path mainly. this is used to validate that a Url
+// matches a specified assertion url.
+pub struct MockUrlMatcher(String);
+impl Match for MockUrlMatcher {
+    fn matches(&self, request: &wiremock::Request) -> bool {
+        if request.url == Url::parse(&self.0).unwrap() {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[test]
+fn env_var_substitution_applies_correctly_in_urls() {
+    let environment = EnvironmentFile {
+        id: String::from("id"),
+        name: String::from("some environment"),
+        values: Some(vec![EnvironmentValue {
+            key: String::from("HOST_URL"),
+            value: String::from("https://httpbin.org"),
+            r#type: String::from("default"),
+            enabled: true,
+        }]),
+    };
+    let raw_url = String::from("{{HOST_URL}}/json");
+    let converted_url = PostieApi::substitute_variables_in_url(&environment, raw_url);
+    assert_eq!(converted_url, "https://httpbin.org/json");
+}
+
+#[test]
+fn returns_base_url_if_env_vars_dont_exist() {
+    let environment = EnvironmentFile {
+        id: String::from("id"),
+        name: String::from("some environment"),
+        values: None,
+    };
+    let raw_url = String::from("{{BOGUS}}/json");
+    let converted_url = PostieApi::substitute_variables_in_url(&environment, raw_url);
+    assert_eq!(converted_url, "{{BOGUS}}/json");
+}
+
+// TODO - figure out how to make this test work to validate the substitution when it is a private
+// method. Goal is to validate the url the reqest client is using.
+//#[tokio::test]
+//async fn it_substitutes_env_vars_into_the_url_and_returns_200() {
+//    let test_app = spawn_test_app().await;
+//    let environment = EnvironmentFile {
+//        id: String::from("id"),
+//        name: String::from("some environment"),
+//        values: Some(vec![EnvironmentValue {
+//            key: String::from("HOST_URL"),
+//            value: String::from("https://httpbin.org"),
+//            r#type: String::from("default"),
+//            enabled: true,
+//        }]),
+//    };
+//    let raw_url = String::from("{{HOST_URL}}/json");
+//    let input = api::HttpRequest {
+//        id: Uuid::new_v4(),
+//        name: None,
+//        method: api::HttpMethod::GET,
+//        url: raw_url,
+//        headers: None,
+//        body: None,
+//        environment: Some(environment),
+//    };
+//    // Given a request to the given url, return a mock 200. This should only work if substitution
+//    // works correctly
+//    Mock::given(method("GET"))
+//        .and(MockUrlMatcher(String::from("https://httpbin.org/json").try_into().unwrap()))
+//        .respond_with(ResponseTemplate::new(200))
+//        .expect(1)
+//        .mount(&test_app.test_server)
+//        .await;
+//            
+//    let _ = PostieApi::make_request(&test_app.app,input);
+//}

--- a/api/tests/api/api.rs
+++ b/api/tests/api/api.rs
@@ -1,4 +1,7 @@
-use api::{domain::environment::{EnvironmentFile, EnvironmentValue}, PostieApi};
+use api::{
+    domain::environment::{EnvironmentFile, EnvironmentValue},
+    PostieApi,
+};
 use reqwest::Url;
 use wiremock::Match;
 
@@ -78,6 +81,6 @@ fn returns_base_url_if_env_vars_dont_exist() {
 //        .expect(1)
 //        .mount(&test_app.test_server)
 //        .await;
-//            
+//
 //    let _ = PostieApi::make_request(&test_app.app,input);
 //}

--- a/api/tests/api/collections.rs
+++ b/api/tests/api/collections.rs
@@ -2,9 +2,9 @@ use api::{domain::collection::CollectionItemOrFolder, PostieApi};
 
 use crate::helpers::spawn_test_app;
 
-#[test]
-fn can_parse_collection_with_all_fields() {
-    let app = spawn_test_app();
+#[tokio::test]
+async fn can_parse_collection_with_all_fields() {
+    let app = spawn_test_app().await;
     let test_collection = app.load_test_collection();
     let parsed = PostieApi::parse_collection(&test_collection);
     assert_eq!(parsed.info.name, "qp-external-partner");

--- a/api/tests/api/environments.rs
+++ b/api/tests/api/environments.rs
@@ -2,9 +2,9 @@ use api::PostieApi;
 
 use crate::helpers::spawn_test_app;
 
-#[test]
-fn can_parse_environment_files() {
-    let app = spawn_test_app();
+#[tokio::test]
+async fn can_parse_environment_files() {
+    let app = spawn_test_app().await;
     let test_environment = app.load_test_environment();
     let parsed = PostieApi::parse_environment(test_environment);
 

--- a/api/tests/api/helpers.rs
+++ b/api/tests/api/helpers.rs
@@ -3,7 +3,7 @@ use wiremock::MockServer;
 
 pub struct TestApp {
     pub app: PostieApi,
-    pub test_server: MockServer
+    pub test_server: MockServer,
 }
 
 impl TestApp {

--- a/api/tests/api/helpers.rs
+++ b/api/tests/api/helpers.rs
@@ -1,13 +1,19 @@
 use api::PostieApi;
+use wiremock::MockServer;
 
 pub struct TestApp {
     pub app: PostieApi,
+    pub test_server: MockServer
 }
 
 impl TestApp {
-    pub fn new() -> Self {
+    pub async fn new() -> Self {
+        let mock_server = MockServer::start().await;
+        let mock_client = reqwest::Client::builder().build().unwrap();
         Self {
+            test_server: mock_server,
             app: PostieApi {
+                client: mock_client,
                 environment: None,
                 collection: Some("test_collection.json".to_string()),
             },
@@ -23,7 +29,7 @@ impl TestApp {
     }
 }
 
-pub fn spawn_test_app() -> TestApp {
+pub async fn spawn_test_app() -> TestApp {
     let app = TestApp::new();
-    app
+    app.await
 }

--- a/api/tests/api/main.rs
+++ b/api/tests/api/main.rs
@@ -1,3 +1,4 @@
+mod api;
 mod collections;
 mod environments;
 mod helpers;


### PR DESCRIPTION
This PR adds some functionality to take a given request url from the Gui, along with a given Environment struct, and substitute the values of the env vars into a final request url that is used by reqwest. Additionally, adds a new "Environment" tab to the right hand side. Not quite 100% same to Postman but I think is the easiest way to maintain.

I was kind of thinking we can load env's from the db to populate the list and then select one of those to be "active" and those values popular the Environment tab with the selected env's values.

Also added some simple unit tests. I wanted to keep the substitute method private, and then build a unit test around validating the reqwest url, but couldn't quite figure it out. Left current thoughts and attempt commented out to go back to later. For now, made the method public so it can be tested directly.