### PR TITLE
Support text response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "snailquote",
  "sqlx",
  "tokio",
  "url",
@@ -3400,6 +3401,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "snailquote"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec62a949bda7f15800481a711909f946e1204f2460f89210eaf7f57730f88f86"
+dependencies = [
+ "thiserror",
+ "unicode_categories",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,30 @@ Mainly started due to a need at work, where Postman cloud accounts are not allow
 save collections and environments.
 - Have full interoperability with existing Postman file formats.
 
+## Current State
+Currently in order to run, Rust must be installed as well as setting up the initial SQLite database (see Database Utils).
+The end goal is to have a fully packaged mac application (sorry Windows, for now) that is able to be downloaded and ran.
+### Supported
+- Submitting GET, POST, PUT, PATCH, DELETE requests
+- POST and PUT requests only support application/json body
+- Valid handling of responses with Content-Type of application/json, text/html, text/plain
+- Environments with variable substition
+- Importing postman colellections
+- Importing postman environments
+- Request history is loading on application start to show previous requests & responses
+
+### Not yet supported
+- Creating new collections from scratch
+- Infinite levels of collection nesting, currently only support one level of folder nesting
+- Exporting saved colellections
+- Exporting saved environments
+- File upload request bodies
+- XML request body and response
+- Pre-request scripts
+- Request history, imported files do not reflect on ui until next application start
+- Native mac application
+- Cloud database and user profiles
+
 ## Database Utils
 
 This project uses the rust `sqlx` and `sqlx-cli` packages to manage a SQLite database connection.

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,6 +10,7 @@ chrono = "0.4.34"
 reqwest = { version = "0.11.24", features = ["blocking", "json"] }
 serde = "1.0.196"
 serde_json = "1.0.113"
+snailquote = "0.3.1"
 uuid = { version = "1.7.0", features = ["v4", "fast-rng"] }
 sqlx = { version = "0.7.3", features = [ "runtime-tokio", "sqlite" ] }
 tokio = { version = "1", features = ["full"] }

--- a/api/src/domain/response.rs
+++ b/api/src/domain/response.rs
@@ -8,7 +8,7 @@ pub struct DBResponse {
     pub name: Option<String>,
     #[sqlx(default)]
     pub headers: Vec<ResponseHeader>,
-    pub body: Option<serde_json::Value>,
+    pub body: Option<String>,
 }
 
 #[derive(

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -9,6 +9,7 @@ use reqwest::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{from_str, json, Value};
+use snailquote::unescape;
 use sqlx::{sqlite::SqliteRow, Connection, Row, SqliteConnection};
 use std::{borrow::Borrow, error::Error, fs, str::FromStr};
 use uuid::Uuid;
@@ -522,12 +523,11 @@ impl PostieDb {
                 let raw_headers: String = row.get("headers");
                 let raw_body: String = row.get("body");
                 let headers = serde_json::from_str::<Vec<ResponseHeader>>(&raw_headers).unwrap();
-                println!("RAW BODY: {:?}", &raw_body);
                 let body = if raw_body.is_empty() {
                     None // or handle the empty case as desired
                 } else {
-                    // Attempt to parse as JSON only if it is not an empty string
-                    serde_json::from_str(&raw_body).ok()
+                    let escaped = unescape(&raw_body).unwrap();
+                    Some(escaped)
                 };
                 DBResponse {
                     id,

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -12,10 +12,9 @@ use eframe::{
     App, NativeOptions,
 };
 use egui::TextStyle;
-use egui_extras::{syntax_highlighting::CodeTheme, Column, TableBuilder};
+use egui_extras::{Column, TableBuilder};
 use egui_json_tree::JsonTree;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::{
     cell::{RefCell, RefMut},
     collections::{HashMap, HashSet},


### PR DESCRIPTION
Added support for plain text response by the creation on a new enum that is used to represent the possible response data types. Can add onto this in the future for xml and other types.

Things are *quite* perfect yet since when the body string is loaded from the db and its attempted to be parsed back to json in order to let the ui know it should render it with the json tree extension, it fails, resulting in the json string being rendered as simple text instead. I think the issue may be the string isn't standard json with double quotes etc? Will try at it a little more but this is a start at least.