### PR TITLE
OAuth2 Token Request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
 name = "api"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.0",
  "chrono",
  "reqwest",
  "serde",
@@ -504,6 +505,12 @@ name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64ct"
@@ -1738,6 +1745,7 @@ name = "gui"
 version = "0.1.0"
 dependencies = [
  "api",
+ "base64 0.22.0",
  "eframe",
  "egui",
  "egui_extras",
@@ -3056,7 +3064,7 @@ version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3157,7 +3165,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -3566,7 +3574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.4",
  "bitflags 2.4.0",
  "byteorder",
  "bytes",
@@ -3608,7 +3616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.4",
  "bitflags 2.4.0",
  "byteorder",
  "crc",
@@ -4795,7 +4803,7 @@ checksum = "ec874e1eef0df2dcac546057fe5e29186f09c378181cd7b635b4b7bcc98e9d81"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64",
+ "base64 0.21.4",
  "deadpool",
  "futures",
  "http 1.0.0",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+base64 = "0.22.0"
 chrono = "0.4.34"
 reqwest = { version = "0.11.24", features = ["blocking", "json"] }
 serde = "1.0.196"

--- a/api/src/db/repository.rs
+++ b/api/src/db/repository.rs
@@ -196,11 +196,11 @@ impl PostieDb {
                 let name: Option<String> = row.get("name");
                 let raw_body: Option<String> = row.get("body");
                 let raw_headers: String = row.get("headers");
-                let mut body: Option<serde_json::Value> = None;
+                let mut body: Option<String> = None;
                 let headers: Vec<request::RequestHeader> =
                     serde_json::from_str::<Vec<RequestHeader>>(&raw_headers).unwrap();
                 if let Some(body_str) = raw_body {
-                    body = serde_json::from_str(&body_str).unwrap()
+                    body = Some(body_str)
                 }
                 DBRequest {
                     id,

--- a/api/src/domain/request.rs
+++ b/api/src/domain/request.rs
@@ -9,7 +9,7 @@ pub struct DBRequest {
     pub name: Option<String>,
     #[sqlx(default)]
     pub headers: Vec<RequestHeader>,
-    pub body: Option<serde_json::Value>,
+    pub body: Option<String>,
 }
 
 #[derive(

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -6,11 +6,11 @@ use db::repository;
 use domain::collection::Collection;
 use domain::environment::EnvironmentFile;
 use reqwest::{
-    header::{HeaderMap, HeaderName, HeaderValue},
+    header::{self, HeaderMap, HeaderName, HeaderValue},
     Method,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::json;
 use std::{borrow::Borrow, error::Error, fs, str::FromStr};
 use uuid::Uuid;
 
@@ -51,14 +51,49 @@ impl FromStr for HttpMethod {
 }
 
 #[derive(Debug)]
+pub enum PostieRequest {
+    HTTP(HttpRequest),
+    OAUTH(OAuth2Request),
+}
+
+#[derive(Debug)]
 pub struct HttpRequest {
     pub id: Uuid,
     pub name: Option<String>,
     pub method: HttpMethod,
     pub url: String,
     pub headers: Option<Vec<(String, String)>>,
-    pub body: Option<Value>,
+    pub body: Option<RequestBody>,
     pub environment: EnvironmentFile,
+}
+
+#[derive(Clone, Debug)]
+pub enum RequestBody {
+    JSON(serde_json::Value),
+    FORM(String),
+}
+
+#[derive(Debug)]
+pub struct OAuth2Request {
+    pub access_token_url: String,
+    pub refresh_url: String,
+    pub client_id: String,
+    pub client_secret: String,
+    pub request: OAuthRequestBody,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OAuthRequestBody {
+    pub grant_type: String,
+    pub scope: String,
+    pub audience: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OAuthResponse {
+    pub access_token: String,
+    pub expires_in: i32,
+    pub token_type: String
 }
 
 #[derive(Debug)]
@@ -178,98 +213,138 @@ impl PostieApi {
             raw_url
         }
     }
-    pub async fn make_request(input: HttpRequest) -> Result<ResponseData, Box<dyn Error>> {
+    pub async fn make_request(input: PostieRequest) -> Result<ResponseData, Box<dyn Error>> {
         let api = PostieApi::new().await;
-        println!("Submitting request: {:?}", input);
-        let method = match input.method {
-            HttpMethod::GET => Method::GET,
-            HttpMethod::POST => Method::POST,
-            HttpMethod::PUT => Method::PUT,
-            HttpMethod::PATCH => Method::PATCH,
-            HttpMethod::DELETE => Method::DELETE,
-            HttpMethod::HEAD => Method::HEAD,
-            HttpMethod::OPTIONS => Method::OPTIONS,
-        };
+        match input {
+            PostieRequest::HTTP(input) => {
+                println!("Submitting http request: {:?}", input);
+                let method = match input.method {
+                    HttpMethod::GET => Method::GET,
+                    HttpMethod::POST => Method::POST,
+                    HttpMethod::PUT => Method::PUT,
+                    HttpMethod::PATCH => Method::PATCH,
+                    HttpMethod::DELETE => Method::DELETE,
+                    HttpMethod::HEAD => Method::HEAD,
+                    HttpMethod::OPTIONS => Method::OPTIONS,
+                };
 
-        let mut headers = HeaderMap::new();
-        if let Some(h) = input.headers.clone() {
-            for (key, value) in h {
-                let header_name = HeaderName::from_bytes(&key.as_bytes()).unwrap();
-                let header_value = HeaderValue::from_str(&value).unwrap();
-                headers.insert(header_name, header_value);
+                let mut headers = HeaderMap::new();
+                if let Some(h) = input.headers.clone() {
+                    for (key, value) in h {
+                        let header_name = HeaderName::from_bytes(&key.as_bytes()).unwrap();
+                        let header_value = HeaderValue::from_str(&value).unwrap();
+                        headers.insert(header_name, header_value);
+                    }
+                };
+
+                let url = Self::substitute_variables_in_url(&input.environment, input.url.clone());
+                let mut req = api.client.request(method, url).headers(headers.clone());
+                if let Some(ref request_body) = input.body {
+                    req = match request_body.clone() {
+                        RequestBody::JSON(j) => req.json(&j.clone()),
+                        RequestBody::FORM(f) => req.form(&f.clone()),
+                    };
+                }
+
+                let now: DateTime<Utc> = Utc::now();
+                let sent_at = std::time::Instant::now();
+                let res = req.send().await?;
+                let response_time = sent_at.elapsed().as_millis();
+                let res_headers = res.headers().clone();
+                let res_status = res.status().clone();
+                let res_type = &res_headers.get("content-type").unwrap().to_str().unwrap();
+                let res_text = res.text().await?;
+                if !res_type.starts_with("application/json")
+                    && !res_type.starts_with("text/plain")
+                    && !res_type.starts_with("text/html")
+                {
+                    // I couldn't figure out how to safely throw an error so I'm just returning this for now
+                    println!(
+                        "expected application/json text/html, or text/plain, got {}",
+                        res_type
+                    );
+                    return Ok(ResponseData::JSON(
+                        json!({"err": "unsupported response type!"}),
+                    ));
+                }
+
+                let request_headers = input
+                    .headers
+                    .clone()
+                    .unwrap()
+                    .into_iter()
+                    .map(|(key, value)| domain::request::RequestHeader { key, value })
+                    .collect();
+                let mut db = repository::PostieDb::new().await;
+                let body = if let Some(req_body) = input.body {
+                    match req_body {
+                        RequestBody::JSON(j) => Some(j.to_string()),
+                        RequestBody::FORM(f) => Some(f),
+                    }
+                } else {
+                    None
+                };
+                let db_request = DBRequest {
+                    id: input.id.to_string(),
+                    body,
+                    name: input.name.clone(),
+                    method: input.method.to_string(),
+                    url: input.url,
+                    headers: request_headers,
+                };
+                let _ = db.save_request_history(&db_request).await?;
+                let response_headers: Vec<domain::response::ResponseHeader> = res_headers
+                    .borrow()
+                    .into_iter()
+                    .map(|(key, value)| domain::response::ResponseHeader {
+                        key: String::from(HeaderName::as_str(&key)),
+                        value: String::from(HeaderValue::to_str(&value).unwrap()),
+                    })
+                    .collect();
+                let db_response = DBResponse {
+                    id: Uuid::new_v4().to_string(),
+                    status_code: res_status.as_u16(),
+                    name: input.name.clone(),
+                    headers: response_headers,
+                    body: Some(res_text.clone()),
+                };
+                let _ = db.save_response(&db_response).await?;
+                let _ = db
+                    .save_request_response_item(&db_request, &db_response, &now, &response_time)
+                    .await?;
+                let response_data = if res_type.starts_with("application/json") {
+                    let res_json = serde_json::from_str(&res_text)?;
+                    ResponseData::JSON(res_json)
+                } else {
+                    ResponseData::TEXT(res_text)
+                };
+                Ok(response_data)
             }
-        };
-
-        let url = Self::substitute_variables_in_url(&input.environment, input.url.clone());
-        let mut req = api.client.request(method, url).headers(headers.clone());
-        if input.body.is_some() {
-            req = req.json(&input.body.clone().unwrap_or_default());
+            PostieRequest::OAUTH(input) => {
+                println!("making ouath request");
+                let auth_header_value =
+                    base64::encode(format!("{}:{}", &input.client_id, &input.client_secret));
+                let mut header_map = HeaderMap::new();
+                let header_value = &format!("Basic {:?}", &auth_header_value);
+                println!("auth header: {}", &header_value);
+                header_map.insert(
+                    header::AUTHORIZATION,
+                    HeaderValue::from_str(header_value).unwrap(),
+                );
+                header_map.insert(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_str("application/x-www-form-urlencoded").unwrap(),
+                );
+                let mut req = api
+                    .client
+                    .request(Method::POST, input.access_token_url)
+                    .headers(header_map);
+                req = req.form(&input.request);
+                let res = req.send().await?;
+                println!("boom");
+                println!("{:?}", res);
+                Ok(ResponseData::JSON(res.json().await.unwrap()))
+            }
         }
-
-        let now: DateTime<Utc> = Utc::now();
-        let sent_at = std::time::Instant::now();
-        let res = req.send().await?;
-        let response_time = sent_at.elapsed().as_millis();
-        let res_headers = res.headers().clone();
-        let res_status = res.status().clone();
-        let res_type = &res_headers.get("content-type").unwrap().to_str().unwrap();
-        let res_text = res.text().await?;
-        if !res_type.starts_with("application/json")
-            && !res_type.starts_with("text/plain")
-            && !res_type.starts_with("text/html")
-        {
-            // I couldn't figure out how to safely throw an error so I'm just returning this for now
-            println!(
-                "expected application/json text/html, or text/plain, got {}",
-                res_type
-            );
-            return Ok(ResponseData::JSON(
-                json!({"err": "unsupported response type!"}),
-            ));
-        }
-
-        let request_headers = input
-            .headers
-            .clone()
-            .unwrap()
-            .into_iter()
-            .map(|(key, value)| domain::request::RequestHeader { key, value })
-            .collect();
-        let mut db = repository::PostieDb::new().await;
-        let db_request = DBRequest {
-            id: input.id.to_string(),
-            body: input.body,
-            name: input.name.clone(),
-            method: input.method.to_string(),
-            url: input.url,
-            headers: request_headers,
-        };
-        let _ = db.save_request_history(&db_request).await?;
-        let response_headers: Vec<domain::response::ResponseHeader> = res_headers
-            .borrow()
-            .into_iter()
-            .map(|(key, value)| domain::response::ResponseHeader {
-                key: String::from(HeaderName::as_str(&key)),
-                value: String::from(HeaderValue::to_str(&value).unwrap()),
-            })
-            .collect();
-        let db_response = DBResponse {
-            id: Uuid::new_v4().to_string(),
-            status_code: res_status.as_u16(),
-            name: input.name.clone(),
-            headers: response_headers,
-            body: Some(res_text.clone()),
-        };
-        let _ = db.save_response(&db_response).await?;
-        let _ = db
-            .save_request_response_item(&db_request, &db_response, &now, &response_time)
-            .await?;
-        let response_data = if res_type.starts_with("application/json") {
-            let res_json = serde_json::from_str(&res_text)?;
-            ResponseData::JSON(res_json)
-        } else {
-            ResponseData::TEXT(res_text)
-        };
-        Ok(response_data)
     }
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -89,11 +89,11 @@ pub struct OAuthRequestBody {
     pub audience: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct OAuthResponse {
     pub access_token: String,
     pub expires_in: i32,
-    pub token_type: String
+    pub token_type: String,
 }
 
 #[derive(Debug)]

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -96,7 +96,7 @@ pub struct OAuthResponse {
     pub token_type: String,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ResponseData {
     JSON(serde_json::Value),
     TEXT(String),
@@ -216,6 +216,7 @@ impl PostieApi {
     pub async fn make_request(input: PostieRequest) -> Result<ResponseData, Box<dyn Error>> {
         let api = PostieApi::new().await;
         match input {
+            // request and save http request
             PostieRequest::HTTP(input) => {
                 println!("Submitting http request: {:?}", input);
                 let method = match input.method {
@@ -320,6 +321,7 @@ impl PostieApi {
                 };
                 Ok(response_data)
             }
+            // if making an oauth token request, dont save to db
             PostieRequest::OAUTH(input) => {
                 println!("making ouath request");
                 let auth_header_value =
@@ -341,7 +343,6 @@ impl PostieApi {
                     .headers(header_map);
                 req = req.form(&input.request);
                 let res = req.send().await?;
-                println!("boom");
                 println!("{:?}", res);
                 Ok(ResponseData::JSON(res.json().await.unwrap()))
             }

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 api= { path = "../api/" }
+base64 = "0.22.0"
 egui = "0.26.2"
 egui_extras = "0.26.2"
 egui_json_tree = "0.4.0"

--- a/gui/src/components/content_header_panel.rs
+++ b/gui/src/components/content_header_panel.rs
@@ -31,7 +31,9 @@ pub fn content_header_panel(gui: &mut Gui, ctx: &egui::Context) {
             ui.text_edit_singleline(&mut gui.url);
             if ui.button("Submit").clicked() {
                 let body = if gui.selected_http_method != HttpMethod::GET {
-                    Some(serde_json::from_str(&gui.body_str).expect("Body is invalid json"))
+                    Some(api::RequestBody::JSON(
+                        serde_json::from_str(&gui.body_str).expect("Body is invalid json"),
+                    ))
                 } else {
                     None
                 };
@@ -44,16 +46,21 @@ pub fn content_header_panel(gui: &mut Gui, ctx: &egui::Context) {
                     .collect();
                 match gui.selected_auth_mode {
                     AuthMode::APIKEY => {
-                        submitted_headers.push(
-                            (String::from(gui.api_key_name.clone()), gui.api_key.clone())
-                        );
-                    },
+                        submitted_headers
+                            .push((String::from(gui.api_key_name.clone()), gui.api_key.clone()));
+                    }
                     AuthMode::BEARER => {
-                        submitted_headers.push(
-                            (String::from("Authorization"),
-                            format!("Bearer {}", gui.api_key))
-                        );
-                    },
+                        submitted_headers.push((
+                            String::from("Authorization"),
+                            format!("Bearer {}", gui.bearer_token),
+                        ));
+                    }
+                    AuthMode::OAUTH2 => {
+                        submitted_headers.push((
+                            String::from("Authorization"),
+                            format!("Bearer {}", gui.oauth_token),
+                        ));
+                    }
                     AuthMode::NONE => (),
                 };
                 let request = HttpRequest {

--- a/gui/src/components/content_panel.rs
+++ b/gui/src/components/content_panel.rs
@@ -28,24 +28,51 @@ pub fn content_panel(gui: &mut Gui, ctx: &egui::Context) {
                             );
                         });
                     });
-                if gui.response.try_read().unwrap().is_some() {
-                    CentralPanel::default().show(ctx, |ui| {
-                        let binding = gui.response.try_read().unwrap();
-                        let r = binding.as_ref().unwrap();
-                        match r {
-                            ResponseData::JSON(json) => {
-                                ScrollArea::vertical().show(ui, |ui| {
-                                    JsonTree::new("response-json", json).show(ui);
-                                });
-                            }
-                            ResponseData::TEXT(text) => {
-                                ScrollArea::vertical().show(ui, |ui| {
-                                    ui.label(text);
-                                });
-                            }
-                        };
-                    });
-                }
+                match gui.response.try_read() {
+                    Ok(response) => {
+                        if response.is_some() {
+                            CentralPanel::default().show(ctx, |ui| {
+                                let binding = gui.response.try_read().unwrap();
+                                let r = binding.as_ref().unwrap();
+                                match r {
+                                    ResponseData::JSON(json) => {
+                                        ScrollArea::vertical().show(ui, |ui| {
+                                            JsonTree::new("response-json", json).show(ui);
+                                        });
+                                    }
+                                    ResponseData::TEXT(text) => {
+                                        ScrollArea::vertical().show(ui, |ui| {
+                                            ui.label(text);
+                                        });
+                                    }
+                                };
+                            });
+                        }
+                    },
+                    Err(_) => {
+                        CentralPanel::default().show(ctx, |ui| {
+                            ui.label("");
+                        });
+                    },
+                };
+                //if gui.response.try_read().expect("couldnt get gui.response lock").is_some() {
+                //    CentralPanel::default().show(ctx, |ui| {
+                //        let binding = gui.response.try_read().unwrap();
+                //        let r = binding.as_ref().unwrap();
+                //        match r {
+                //            ResponseData::JSON(json) => {
+                //                ScrollArea::vertical().show(ui, |ui| {
+                //                    JsonTree::new("response-json", json).show(ui);
+                //                });
+                //            }
+                //            ResponseData::TEXT(text) => {
+                //                ScrollArea::vertical().show(ui, |ui| {
+                //                    ui.label(text);
+                //                });
+                //            }
+                //        };
+                //    });
+                //}
             }
             RequestWindowMode::PARAMS => {
                 CentralPanel::default().show(ctx, |ui| {
@@ -156,36 +183,36 @@ pub fn content_panel(gui: &mut Gui, ctx: &egui::Context) {
                                 AuthMode::NONE => (),
                             };
                         });
-                    TopBottomPanel::bottom("oauth_response")
-                        .resizable(true)
-                        .show(ctx, |_ui| {
-                            TopBottomPanel::bottom("oauth_token_panel")
-                                .resizable(true)
-                                .show(ctx, |ui| {
-                                    let mut lock = gui.received_token.lock().expect("couldnt lock");
-                                    if !*lock {
-                                        if let Ok(res) = receiver.try_recv() {
-                                            *lock = true;
-                                            if let Some(r) = res {
-                                                println!("{:?}", &r);
-                                                match r {
-                                                    ResponseData::JSON(j) => {
-                                                        let data = serde_json::from_value::<
-                                                            api::OAuthResponse,
-                                                        >(
-                                                            j
-                                                        )
-                                                        .unwrap();
-                                                        ui.label(data.access_token.clone());
-                                                        gui.t = data.access_token.clone();
-                                                    }
-                                                    ResponseData::TEXT(_t) => todo!(),
-                                                }
-                                            }
-                                        }
-                                    }
-                                });
-                        })
+                    //TopBottomPanel::bottom("oauth_response")
+                    //    .resizable(true)
+                    //    .show(ctx, |_ui| {
+                    //        TopBottomPanel::bottom("oauth_token_panel")
+                    //            .resizable(true)
+                    //            .show(ctx, |ui| {
+                    //                let mut lock = gui.received_token.lock().expect("couldnt lock");
+                    //                if !*lock {
+                    //                    if let Ok(res) = receiver.try_recv() {
+                    //                        *lock = true;
+                    //                        if let Some(r) = res {
+                    //                            println!("{:?}", &r);
+                    //                            match r {
+                    //                                ResponseData::JSON(j) => {
+                    //                                    let data = serde_json::from_value::<
+                    //                                        api::OAuthResponse,
+                    //                                    >(
+                    //                                        j
+                    //                                    )
+                    //                                    .unwrap();
+                    //                                    ui.label(data.access_token.clone());
+                    //                                    gui.t = data.access_token.clone();
+                    //                                }
+                    //                                ResponseData::TEXT(_t) => todo!(),
+                    //                            }
+                    //                        }
+                    //                    }
+                    //                }
+                    //            });
+                    //    })
                 });
             }
             RequestWindowMode::HEADERS => {

--- a/gui/src/components/content_panel.rs
+++ b/gui/src/components/content_panel.rs
@@ -94,78 +94,66 @@ pub fn content_panel(gui: &mut Gui, ctx: &egui::Context) {
                                     ui.text_edit_multiline(&mut gui.bearer_token);
                                 }
                                 AuthMode::OAUTH2 => {
-                                            ui.heading("Configure New Token");
-                                            ui.horizontal(|ui| {
-                                                ui.label("Access Token Url");
-                                                ui.text_edit_singleline(
-                                                    &mut gui.oauth_config.access_token_url,
-                                                );
-                                            });
-                                            ui.horizontal(|ui| {
-                                                ui.label("Client ID");
-                                                ui.text_edit_singleline(
-                                                    &mut gui.oauth_config.client_id,
-                                                );
-                                            });
-                                            ui.horizontal(|ui| {
-                                                ui.label("Client Secret");
-                                                ui.text_edit_singleline(
-                                                    &mut gui.oauth_config.client_secret,
-                                                );
-                                            });
-                                            ui.horizontal(|ui| {
-                                                ui.label("Scope");
-                                                ui.text_edit_singleline(
-                                                    &mut gui.oauth_config.request.scope,
-                                                );
-                                            });
-                                            ui.horizontal(|ui| {
-                                                ui.label("Audience");
-                                                ui.text_edit_singleline(
-                                                    &mut gui.oauth_config.request.audience,
-                                                );
-                                            });
+                                    ui.horizontal(|ui| {
+                                        ui.label("Token Result:");
+                                        ui.text_edit_multiline(&mut gui.t);
+                                    });
+                                    ui.heading("Configure New Token");
+                                    ui.horizontal(|ui| {
+                                        ui.label("Access Token Url");
+                                        ui.text_edit_singleline(
+                                            &mut gui.oauth_config.access_token_url,
+                                        );
+                                    });
+                                    ui.horizontal(|ui| {
+                                        ui.label("Client ID");
+                                        ui.text_edit_singleline(&mut gui.oauth_config.client_id);
+                                    });
+                                    ui.horizontal(|ui| {
+                                        ui.label("Client Secret");
+                                        ui.text_edit_singleline(
+                                            &mut gui.oauth_config.client_secret,
+                                        );
+                                    });
+                                    ui.horizontal(|ui| {
+                                        ui.label("Scope");
+                                        ui.text_edit_singleline(
+                                            &mut gui.oauth_config.request.scope,
+                                        );
+                                    });
+                                    ui.horizontal(|ui| {
+                                        ui.label("Audience");
+                                        ui.text_edit_singleline(
+                                            &mut gui.oauth_config.request.audience,
+                                        );
+                                    });
 
-                                            if ui.button("Request Token").clicked() {
-                                                println!("requesting token");
-                                                let oauth_input = api::OAuth2Request {
-                                                    access_token_url: gui
-                                                        .oauth_config
-                                                        .access_token_url
-                                                        .clone(),
-                                                    refresh_url: gui
-                                                        .oauth_config
-                                                        .refresh_url
-                                                        .clone(),
-                                                    client_id: gui.oauth_config.client_id.clone(),
-                                                    client_secret: gui
-                                                        .oauth_config
-                                                        .client_secret
-                                                        .clone(),
-                                                    request: api::OAuthRequestBody {
-                                                        grant_type: gui
-                                                            .oauth_config
-                                                            .request
-                                                            .grant_type
-                                                            .clone(),
-                                                        scope: gui
-                                                            .oauth_config
-                                                            .request
-                                                            .scope
-                                                            .clone(),
-                                                        audience: gui
-                                                            .oauth_config
-                                                            .request
-                                                            .audience
-                                                            .clone(),
-                                                    },
-                                                };
-                                                let _ = Gui::spawn_ouath_request(
-                                                    sender,
-                                                    oauth_response.clone(),
-                                                    oauth_input,
-                                                );
-                                            };
+                                    if ui.button("Request Token").clicked() {
+                                        println!("requesting token");
+                                        let oauth_input = api::OAuth2Request {
+                                            access_token_url: gui
+                                                .oauth_config
+                                                .access_token_url
+                                                .clone(),
+                                            refresh_url: gui.oauth_config.refresh_url.clone(),
+                                            client_id: gui.oauth_config.client_id.clone(),
+                                            client_secret: gui.oauth_config.client_secret.clone(),
+                                            request: api::OAuthRequestBody {
+                                                grant_type: gui
+                                                    .oauth_config
+                                                    .request
+                                                    .grant_type
+                                                    .clone(),
+                                                scope: gui.oauth_config.request.scope.clone(),
+                                                audience: gui.oauth_config.request.audience.clone(),
+                                            },
+                                        };
+                                        let _ = Gui::spawn_ouath_request(
+                                            sender,
+                                            oauth_response.clone(),
+                                            oauth_input,
+                                        );
+                                    };
                                 }
                                 AuthMode::NONE => (),
                             };
@@ -190,7 +178,8 @@ pub fn content_panel(gui: &mut Gui, ctx: &egui::Context) {
                                                             j
                                                         )
                                                         .unwrap();
-                                                        ui.label(data.access_token);
+                                                        ui.label(data.access_token.clone());
+                                                        gui.t = data.access_token.clone();
                                                     }
                                                     ResponseData::TEXT(_t) => todo!(),
                                                 }

--- a/gui/src/components/content_panel.rs
+++ b/gui/src/components/content_panel.rs
@@ -1,6 +1,6 @@
 use std::cell::RefMut;
 
-use api::{domain::environment::EnvironmentValue, ResponseData};
+use api::{domain::environment::EnvironmentValue, OAuthResponse, ResponseData};
 use egui::{CentralPanel, ComboBox, ScrollArea, TextEdit, TextStyle, TopBottomPanel};
 use egui_extras::{Column, TableBuilder};
 use egui_json_tree::JsonTree;
@@ -55,9 +55,26 @@ pub fn content_panel(gui: &mut Gui, ctx: &egui::Context) {
                     ComboBox::from_label("")
                         .selected_text(format!("{:?}", gui.selected_auth_mode))
                         .show_ui(ui, |ui| {
-                            ui.selectable_value(&mut gui.selected_auth_mode, AuthMode::BEARER, "Bearer");
-                            ui.selectable_value(&mut gui.selected_auth_mode, AuthMode::APIKEY, "Api Key");
-                            ui.selectable_value(&mut gui.selected_auth_mode, AuthMode::NONE, "None");
+                            ui.selectable_value(
+                                &mut gui.selected_auth_mode,
+                                AuthMode::BEARER,
+                                "Bearer",
+                            );
+                            ui.selectable_value(
+                                &mut gui.selected_auth_mode,
+                                AuthMode::APIKEY,
+                                "Api Key",
+                            );
+                            ui.selectable_value(
+                                &mut gui.selected_auth_mode,
+                                AuthMode::OAUTH2,
+                                "OAuth2",
+                            );
+                            ui.selectable_value(
+                                &mut gui.selected_auth_mode,
+                                AuthMode::NONE,
+                                "None",
+                            );
                         });
                     match gui.selected_auth_mode {
                         AuthMode::APIKEY => {
@@ -65,14 +82,71 @@ pub fn content_panel(gui: &mut Gui, ctx: &egui::Context) {
                             ui.text_edit_multiline(&mut gui.api_key);
                             ui.label("Header Name");
                             ui.text_edit_singleline(&mut gui.api_key_name);
-                        },
+                        }
                         AuthMode::BEARER => {
                             ui.label("Enter Bearer Token");
                             ui.text_edit_multiline(&mut gui.bearer_token);
-                        },
-                        AuthMode::NONE => {
-                            ui.label("None");
                         }
+                        AuthMode::OAUTH2 => {
+                            ui.horizontal(|ui| {
+                                ui.label("Current Token");
+                                ui.text_edit_singleline(&mut gui.oauth_token);
+                            });
+                            ui.heading("Configure New Token");
+                            ui.horizontal(|ui| {
+                                ui.label("Access Token Url");
+                                ui.text_edit_singleline(&mut gui.oauth_config.access_token_url);
+                            });
+                            ui.horizontal(|ui| {
+                                ui.label("Client ID");
+                                ui.text_edit_singleline(&mut gui.oauth_config.client_id);
+                            });
+                            ui.horizontal(|ui| {
+                                ui.label("Client Secret");
+                                ui.text_edit_singleline(&mut gui.oauth_config.client_secret);
+                            });
+                            ui.horizontal(|ui| {
+                                ui.label("Scope");
+                                ui.text_edit_singleline(&mut gui.oauth_config.request.scope);
+                            });
+                            ui.horizontal(|ui| {
+                                ui.label("Audience");
+                                ui.text_edit_singleline(&mut gui.oauth_config.request.audience);
+                            });
+
+                            if ui.button("Request Token").clicked() {
+                                println!("requesting token");
+                                let oauth_input = api::OAuth2Request {
+                                    access_token_url: gui.oauth_config.access_token_url.clone(),
+                                    refresh_url: gui.oauth_config.refresh_url.clone(),
+                                    client_id: gui.oauth_config.client_id.clone(),
+                                    client_secret: gui.oauth_config.client_secret.clone(),
+                                    request: api::OAuthRequestBody {
+                                        grant_type: gui.oauth_config.request.grant_type.clone(),
+                                        scope: gui.oauth_config.request.scope.clone(),
+                                        audience: gui.oauth_config.request.audience.clone(),
+                                    },
+                                };
+
+                                let token_for_worker = gui.oauth_response.clone();
+                                tokio::spawn(async move {
+                                    let mut token_write_guard =
+                                        token_for_worker.try_write().unwrap();
+                                    let res = Gui::oauth_token_request(oauth_input).await;
+                                    format!("{:?}", &res);
+                                    let res_body = match res.unwrap() {
+                                        api::ResponseData::JSON(json) => json,
+                                        api::ResponseData::TEXT(_) => {
+                                            panic!("unexpected text response")
+                                        }
+                                    };
+                                    let res_json: OAuthResponse = serde_json::from_value(res_body).unwrap();
+                                    *token_write_guard = Some(res_json.access_token);
+                                });
+                            }
+
+                        }
+                        AuthMode::NONE => (),
                     };
                 });
             }

--- a/gui/src/components/content_panel.rs
+++ b/gui/src/components/content_panel.rs
@@ -10,7 +10,6 @@ use crate::{AuthMode, Gui, RequestWindowMode};
 pub fn content_panel(gui: &mut Gui, ctx: &egui::Context) {
     let sender = &mut gui.sender.clone();
     let receiver = &mut gui.receiver;
-    let oauth_response = &mut gui.oauth_response;
     if let Ok(request_window_mode) = gui.request_window_mode.try_read() {
         match *request_window_mode {
             RequestWindowMode::BODY => {
@@ -150,7 +149,6 @@ pub fn content_panel(gui: &mut Gui, ctx: &egui::Context) {
                                         };
                                         let _ = Gui::spawn_ouath_request(
                                             sender,
-                                            oauth_response.clone(),
                                             oauth_input,
                                         );
                                     };

--- a/gui/src/components/content_side_panel.rs
+++ b/gui/src/components/content_side_panel.rs
@@ -132,8 +132,6 @@ pub fn content_side_panel(gui: &mut Gui, ctx: &egui::Context) {
                                     HttpMethod::from_str(&historical_request.method).unwrap();
                                 match &historical_request.body {
                                     Some(body_json) => {
-                                        //let body_str =
-                                         //   serde_json::from_value(body_json.clone()).unwrap();
                                         gui.body_str = body_json.to_string();
                                     }
                                     None => gui.body_str = String::from(""),

--- a/gui/src/components/content_side_panel.rs
+++ b/gui/src/components/content_side_panel.rs
@@ -132,9 +132,9 @@ pub fn content_side_panel(gui: &mut Gui, ctx: &egui::Context) {
                                     HttpMethod::from_str(&historical_request.method).unwrap();
                                 match &historical_request.body {
                                     Some(body_json) => {
-                                        let body_str =
-                                            serde_json::from_value(body_json.clone()).unwrap();
-                                        gui.body_str = body_str;
+                                        //let body_str =
+                                         //   serde_json::from_value(body_json.clone()).unwrap();
+                                        gui.body_str = body_json.to_string();
                                     }
                                     None => gui.body_str = String::from(""),
                                 }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -132,15 +132,15 @@ impl Default for Gui {
             oauth_response: Arc::new(RwLock::new(None)),
             oauth_token: "".into(),
             oauth_config: api::OAuth2Request {
-                access_token_url: "https://test-lmidp.libertymutual.com/as/token.oauth2".into(),
+                access_token_url: "".into(),
                 refresh_url: "".into(),
-                client_id: "uscm_rdmparserclt_2".into(),
-                client_secret: "1634376a-ce4d-4b53-92ea-fab31f20aa77".into(),
+                client_id: "".into(),
+                client_secret: "".into(),
                 request: api::OAuthRequestBody {
                     grant_type: "client_credentials".into(),
-                    scope: "quote".into(),
+                    scope: "".into(),
                     audience:
-                        "https://qp-api-gateway.test.amazon-web-services-797312992947-us-east-1/"
+                        ""
                             .into(),
                 },
             },

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -97,6 +97,7 @@ pub struct Gui {
     pub sender: tokio::sync::mpsc::Sender<Option<ResponseData>>,
     pub receiver: tokio::sync::mpsc::Receiver<Option<ResponseData>>,
     pub received_token: Arc<Mutex<bool>>,
+    pub t: String,
 }
 impl Default for Gui {
     fn default() -> Self {
@@ -132,15 +133,15 @@ impl Default for Gui {
             oauth_response: Arc::new(RwLock::new(None)),
             oauth_token: "".into(),
             oauth_config: api::OAuth2Request {
-                access_token_url: "".into(),
+                access_token_url: "https://test-lmidp.libertymutual.com/as/token.oauth2".into(),
                 refresh_url: "".into(),
-                client_id: "".into(),
-                client_secret: "".into(),
+                client_id: "uscm_rdmparserclt_2".into(),
+                client_secret: "1634376a-ce4d-4b53-92ea-fab31f20aa77".into(),
                 request: api::OAuthRequestBody {
                     grant_type: "client_credentials".into(),
-                    scope: "".into(),
+                    scope: "quote".into(),
                     audience:
-                        ""
+                        "https://qp-api-gateway.test.amazon-web-services-797312992947-us-east-1/"
                             .into(),
                 },
             },
@@ -158,6 +159,7 @@ impl Default for Gui {
             sender,
             receiver,
             received_token: Arc::new(Mutex::new(false)),
+            t: "".into(),
         }
     }
 }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -133,15 +133,15 @@ impl Default for Gui {
             oauth_response: Arc::new(RwLock::new(None)),
             oauth_token: "".into(),
             oauth_config: api::OAuth2Request {
-                access_token_url: "https://test-lmidp.libertymutual.com/as/token.oauth2".into(),
+                access_token_url: "".into(),
                 refresh_url: "".into(),
-                client_id: "uscm_rdmparserclt_2".into(),
-                client_secret: "1634376a-ce4d-4b53-92ea-fab31f20aa77".into(),
+                client_id: "".into(),
+                client_secret: "".into(),
                 request: api::OAuthRequestBody {
                     grant_type: "client_credentials".into(),
-                    scope: "quote".into(),
+                    scope: "".into(),
                     audience:
-                        "https://qp-api-gateway.test.amazon-web-services-797312992947-us-east-1/"
+                        ""
                             .into(),
                 },
             },

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -291,16 +291,13 @@ impl Gui {
     }
     fn spawn_ouath_request(
         sender: &mut tokio::sync::mpsc::Sender<Option<ResponseData>>,
-        oauth_response: Arc<RwLock<Option<ResponseData>>>,
         input: api::OAuth2Request,
     ) -> Result<(), Box<dyn Error>> {
         let sender_for_worker = sender.clone();
-        let mut _token_write_guard = oauth_response.try_write().unwrap();
         tokio::spawn(async move {
             match Self::oauth_token_request(input).await {
                 Ok(res) => {
                     println!("OAuth Response: {:?}", res);
-                    //*token_write_guard = Some(res.clone());
                     _ = sender_for_worker.send(Some(res)).await;
                 }
                 Err(_err) => {

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -96,12 +96,11 @@ pub struct Gui {
     pub import_result: Arc<Mutex<Option<String>>>,
     pub sender: tokio::sync::mpsc::Sender<Option<ResponseData>>,
     pub receiver: tokio::sync::mpsc::Receiver<Option<ResponseData>>,
-    pub received_token: Arc<Mutex<bool>>,
-    pub t: String,
+    pub received_token: Arc<Mutex<bool>>
 }
 impl Default for Gui {
     fn default() -> Self {
-        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
         Self {
             response: Arc::new(RwLock::new(None)),
             headers: Rc::new(RefCell::new(vec![
@@ -133,15 +132,14 @@ impl Default for Gui {
             oauth_response: Arc::new(RwLock::new(None)),
             oauth_token: "".into(),
             oauth_config: api::OAuth2Request {
-                access_token_url: "".into(),
+                access_token_url: "https://test-lmidp.libertymutual.com/as/token.oauth2".into(),
                 refresh_url: "".into(),
-                client_id: "".into(),
-                client_secret: "".into(),
+                client_id: "uscm_rdmparserclt_2".into(),
+                client_secret: "1634376a-ce4d-4b53-92ea-fab31f20aa77".into(),
                 request: api::OAuthRequestBody {
                     grant_type: "client_credentials".into(),
-                    scope: "".into(),
-                    audience:
-                        ""
+                    scope: "quote".into(),
+                    audience: "https://qp-api-gateway.test.amazon-web-services-797312992947-us-east-1/"
                             .into(),
                 },
             },
@@ -158,8 +156,7 @@ impl Default for Gui {
             import_result: Arc::new(Mutex::new(None)),
             sender,
             receiver,
-            received_token: Arc::new(Mutex::new(false)),
-            t: "".into(),
+            received_token: Arc::new(Mutex::new(false))
         }
     }
 }


### PR DESCRIPTION
Implements a simple oauth2 token request. I kind of fumbled around the state management and getting the ui to actually update the value with the resulting token. Trying to reference the value of the RwLock typed value resulted in borrow checker errors, so my solution was to make a separate static string variable that will be updated once the request is successful. 

In order to accomplish this some base functionality was extended, like the support for different request body types (just json and form now).

This variable to tied to an text field so when the button gets pressed, the worker thread handles the async request in the separate tokio::spawn block, that uses a channel to send a value back to the main thread, which receives the value and updates the static string value in the Gui struct which ultimately updates the input box.

There is probably a more idiomatic way? Hell if I know :) 